### PR TITLE
feat: add support for trim property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.honton.chas</groupId>
   <artifactId>readfiles-maven-plugin</artifactId>
-  <version>0.0.1</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Read Files Maven Plugin</name>
@@ -153,6 +153,7 @@
         <version>2.0.0</version>
         <configuration>
           <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
+          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
         </configuration>
         <executions>
           <execution>

--- a/src/it/multiline-trim/invoker.properties
+++ b/src/it/multiline-trim/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = process-resources
+invoker.failureBehavior = fail-at-end

--- a/src/it/multiline-trim/pom.xml
+++ b/src/it/multiline-trim/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.honton.chas</groupId>
+    <artifactId>readfiles-it-parent</artifactId>
+    <version>0.0.1</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>readfiles-multiline-it</artifactId>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-property</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <rules>
+                <requireProperty>
+                  <property>multiline</property>
+                  <regex>^one,\r?\ntwo,\r?\nthree$</regex>
+                </requireProperty>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.honton.chas</groupId>
+        <artifactId>readfiles-maven-plugin</artifactId>
+        <configuration>
+          <trim>true</trim>
+          <files>
+            <file>${basedir}/src/main/resources/multiline</file>
+          </files>
+        </configuration>
+      </plugin>
+    </plugins>
+
+  </build>
+
+</project>

--- a/src/it/multiline-trim/src/main/resources/multiline
+++ b/src/it/multiline-trim/src/main/resources/multiline
@@ -1,0 +1,3 @@
+one,
+two,
+three

--- a/src/it/pom.xml
+++ b/src/it/pom.xml
@@ -31,7 +31,7 @@
       <plugin>
         <groupId>org.honton.chas</groupId>
         <artifactId>readfiles-maven-plugin</artifactId>
-        <version>0.0.1</version>
+        <version>@pom.version@</version>
         <executions>
           <execution>
             <goals>

--- a/src/it/prefix-trim/invoker.properties
+++ b/src/it/prefix-trim/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = process-resources
+invoker.failureBehavior = fail-at-end

--- a/src/it/prefix-trim/pom.xml
+++ b/src/it/prefix-trim/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.honton.chas</groupId>
+    <artifactId>readfiles-it-parent</artifactId>
+    <version>0.0.1</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>readfiles-prefix-it</artifactId>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-property</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <rules>
+                <requireProperty>
+                  <property>Xoneline</property>
+                  <regex>^one,two,three$</regex>
+                </requireProperty>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.honton.chas</groupId>
+        <artifactId>readfiles-maven-plugin</artifactId>
+        <configuration>
+          <prefix>X</prefix>
+          <files>
+            <file>${basedir}/src/main/resources/oneline</file>
+          </files>
+        </configuration>
+      </plugin>
+    </plugins>
+
+  </build>
+
+</project>

--- a/src/it/prefix-trim/pom.xml
+++ b/src/it/prefix-trim/pom.xml
@@ -44,6 +44,7 @@
           <files>
             <file>${basedir}/src/main/resources/oneline</file>
           </files>
+          <trim>true</trim>
         </configuration>
       </plugin>
     </plugins>

--- a/src/it/prefix-trim/src/main/resources/oneline
+++ b/src/it/prefix-trim/src/main/resources/oneline
@@ -1,0 +1,1 @@
+one,two,three

--- a/src/main/java/org/honton/chas/maven/readfiles/ReadFilesMojo.java
+++ b/src/main/java/org/honton/chas/maven/readfiles/ReadFilesMojo.java
@@ -28,7 +28,7 @@ public class ReadFilesMojo extends AbstractMojo {
   /**
    * Whether to trim leading and trailing whitespace characters.
    * 
-   * @since 0.0.2
+   * @since 0.1.0
    */
   @Parameter(defaultValue = "false", property = "readfiles.trim")
   private boolean trim;

--- a/src/main/java/org/honton/chas/maven/readfiles/ReadFilesMojo.java
+++ b/src/main/java/org/honton/chas/maven/readfiles/ReadFilesMojo.java
@@ -26,6 +26,14 @@ public class ReadFilesMojo extends AbstractMojo {
   private String prefix;
 
   /**
+   * Whether to trim leading and trailing whitespace characters.
+   * 
+   * @since 0.0.2
+   */
+  @Parameter(defaultValue = "false", property = "readfiles.trim")
+  private boolean trim;
+
+  /**
    * Charset encoding of the source files.  Defaults to UTF-8
    */
   @Parameter(defaultValue = "${project.build.sourceEncoding}")
@@ -84,6 +92,10 @@ public class ReadFilesMojo extends AbstractMojo {
 
   private String readFileFully(File file) throws IOException {
     byte[] encoded = Files.readAllBytes(file.toPath());
-    return new String(encoded, charset);
+    final String result = new String(encoded, charset);
+    if (this.trim) {
+      return result.trim();
+    }
+    return result;
   }
 }


### PR DESCRIPTION
The idea is to support the trimming of file contents. Use cases are (for example) reading the contents of some .nvmrc (or java-version file contents) which may contain trailing whitespace (or new line) characters.

Also this PR does the following:

1. Fix integration test to use the current version being built (by cloning projects and using `@pom.version` filtered property)
2. Bump version to 0.1.0-SNAPSHOT (wild call, I give you that)

Fixes #1 