### PR TITLE
chore: fix thread safe plugin indicator

### DIFF
--- a/src/main/java/org/honton/chas/maven/readfiles/ReadFilesMojo.java
+++ b/src/main/java/org/honton/chas/maven/readfiles/ReadFilesMojo.java
@@ -16,7 +16,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * Read files into maven properties.  The contents of each file is read in full.  The content is
  * then assigned to a maven property of the same name.
  */
-@Mojo(name = "readfiles", defaultPhase = LifecyclePhase.INITIALIZE)
+@Mojo(name = "readfiles", defaultPhase = LifecyclePhase.INITIALIZE, threadSafe = true)
 public class ReadFilesMojo extends AbstractMojo {
 
   /**


### PR DESCRIPTION
Fixes the below warnings when running using concurrent builds:

```
Warning:  *****************************************************************
Warning:  * Your build is requesting parallel execution, but this         *
Warning:  * project contains the following plugin(s) that have goals not  *
Warning:  * marked as thread-safe to support parallel execution.          *
Warning:  * While this /may/ work fine, please look for plugin updates    *
Warning:  * and/or request plugins be made thread-safe.                   *
Warning:  * If reporting an issue, report it against the plugin in        *
Warning:  * question, not against Apache Maven.                           *
Warning:  *****************************************************************
Warning:  The following plugins are not marked as thread-safe in [...]:
Warning:    org.honton.chas:readfiles-maven-plugin:0.0.1
Warning:  
Warning:  Enable debug to see precisely which goals are not marked as thread-safe.
Warning:  *****************************************************************
```

It turns out that:

1. This plugin's goals are actually thread safe
2. It's only a matter of changing an annotation's value